### PR TITLE
Bug/set alarm

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "@types/react": "~19.0.10",
         "eslint": "^9.25.0",
         "eslint-config-expo": "~9.2.0",
+        "husky": "^9.1.7",
         "typescript": "~5.8.3",
         "yaml-lint": "^1.7.0"
       }
@@ -7966,6 +7967,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/hyphenate-style-name": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "expo lint && npx tsc --noEmit",
-    "fetch-wind": "node ./scripts/fetch-wind-data.mjs"
+    "lint": "expo lint && npx tsc --noEmit && npx yaml-lint .github/workflows/",
+    "fetch-wind": "node ./scripts/fetch-wind-data.mjs",
+    "prepare": "husky"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -53,6 +54,7 @@
     "@types/react": "~19.0.10",
     "eslint": "^9.25.0",
     "eslint-config-expo": "~9.2.0",
+    "husky": "^9.1.7",
     "typescript": "~5.8.3",
     "yaml-lint": "^1.7.0"
   },


### PR DESCRIPTION
This pull request introduces enhancements to the `SettingsScreen` component, updates the linting process, and integrates Husky for pre-commit hooks. The most significant changes include improving time input validation and formatting, updating linting to include YAML files, and adding Husky to enforce pre-commit checks.

### Time validation improvements:
* [`app/(tabs)/settings.tsx`](diffhunk://#diff-508a25a6a97ebb3c75b31f13dcaf0fe720319c0f23b54258fd151a39b43f7938L248-R293): Updated the time validation logic to allow more flexible input formats (e.g., "1730" or "5") and added auto-correction for valid formats while showing alerts for invalid ones without resetting the value.  
* [`app/(tabs)/settings.tsx`](diffhunk://#diff-508a25a6a97ebb3c75b31f13dcaf0fe720319c0f23b54258fd151a39b43f7938L268-R302): Updated the hint text to reflect the new supported time formats.

### Code quality enhancements:
* [`.husky/pre-commit`](diffhunk://#diff-d2bc4bbf14eadc292d84e0ef5f7a93115c23557f533809fc80b896934291529dR1): Added a pre-commit hook to run linting automatically using Husky.  
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R12): Updated the linting command to include YAML linting for GitHub workflows and added Husky as a dependency. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L10-R12) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R57)