### PR TITLE
feat: add Boulder Reservoir wind monitoring tab

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,6 +6,8 @@
 - Always fix all linting errors and warnings before submitting code.
 - Install javascript libraries locally instead of globally with `-g`.
 - All npm scripts should also be VSCode tasks located in `.vscode/tasks.json`
+- This application is built and released using github actions in .github/workflows
+- It is manually published to the playstore and App store using the release notes from github actions as the release notes for the app store releases.
 
 ## Documentation - STRICT ANTI-SPRAWL POLICY
 - **ONLY 3 documentation files allowed:**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -6,8 +6,8 @@
 - Always fix all linting errors and warnings before submitting code.
 - Install javascript libraries locally instead of globally with `-g`.
 - All npm scripts should also be VSCode tasks located in `.vscode/tasks.json`
-- This application is built and released using github actions in .github/workflows
-- It is manually published to the playstore and App store using the release notes from github actions as the release notes for the app store releases.
+- This application is built and released using GitHub Actions in .github/workflows
+- It is manually published to the Play Store and App Store using the release notes from GitHub Actions as the release notes for the app store releases.
 
 ## Documentation - STRICT ANTI-SPRAWL POLICY
 - **ONLY 3 documentation files allowed:**

--- a/README.md
+++ b/README.md
@@ -1,164 +1,71 @@
-# Dawn Patrol - Soda Lake Wind Monitor
+# Dawn Patrol - Wind Monitor
 
-A wind monitoring app for Soda Lake (Soda Lake Dam 1) in Colorado that helps you decide whether it's worth heading out for water sports based on real-time wind conditions and advanced meteorological analysis.
+A wind monitoring app for Colorado lakes (Soda Lake, Standley Lake, Boulder Reservoir) that helps you decide whether it's worth heading out for water sports based on real-time wind conditions from Ecowitt weather stations.
 
 ## Features
 
-- **Real-time Wind Monitoring**: Live wind conditions at Soda Lake and Standley Lake
-- **Smart Analysis**: Advanced wind pattern analysis with multiple data sources
-- **Configurable Thresholds**: Customize wind speed preferences for visual indicators
-- **Standley Lake Monitor**: Real-time wind conditions via Ecowitt weather stations
+- **Real-time Wind Monitoring**: Live wind speed and direction from Ecowitt weather stations
+- **Multi-Station Support**: Soda Lake, Standley Lake, and Boulder Reservoir tabs
+- **Custom Wind Charts**: SVG charts with horizontal scrolling, gap handling, and time labels
+- **Configurable Thresholds**: Set your minimum wind speed for visual threshold indicators
+- **Transmission Quality**: Detects antenna issues and explains data gaps
 - **Wind Guru (Experimental)**: Advanced katabatic wind predictions (server migration in progress)
 
-## Wind Guru Tab
+## Tabs
 
-**Experimental Feature — Server Migration In Progress**
-
-The Wind Guru tab provides advanced katabatic wind predictions for Morrison, CO. It is currently an experimental feature (disabled by default) that can be enabled in Settings under "App Features."
-
-The tab currently shows a server migration notice — the local prediction engine has been removed and server-based predictions are under development. When complete, the server system will provide:
-
-- Machine learning models for pattern recognition
-- Real-time processing and instant prediction updates
-- Multi-location analysis across wind sites
-- Improved accuracy via sophisticated weather modeling
+| Tab | Description |
+|-----|-------------|
+| **Soda Lake** (Home) | Real-time wind at Soda Lake Dam 1 |
+| **Standley Lake** | Real-time wind at Standley Lake |
+| **Boulder Res** | Real-time wind at Boulder Reservoir |
+| **Wind Guru** | Experimental predictions (disabled by default, enable in Settings) |
+| **Settings** | Threshold config, Wind Guru toggle, app info |
 
 ## Getting Started
 
-### Download Options
+### Download
 
-- Private Link
+- Private link (contact repo owner)
 
-## How It Works
+### Using the App
 
-The Dawn Patrol app helps you decide when to head to the beach by analyzing wind patterns at Soda Lake using multiple data sources and advanced meteorological models.
+1. **View wind conditions** — open the app and select your lake tab
+2. **Pull to refresh** — swipe down to get latest data
+3. **Set your threshold** — go to Settings → Wind Display → adjust minimum wind speed
+4. **Check charts** — scroll horizontally to see wind history throughout the day
 
-### Wind Monitoring
+### Settings
 
-1. **Real-time Data**: The app continuously monitors wind conditions from multiple sources
-2. **Pattern Analysis**: Uses historical patterns and current conditions to assess quality
-3. **Visual Indicators**: Wind charts show your configurable threshold as a reference line
-4. **Multiple Sources**: Combines government weather data with local weather stations
+- **Wind Threshold**: Minimum wind speed (mph) shown as a reference line on charts
+- **Wind Guru Toggle**: Enable/disable the experimental prediction tab
 
-### Default Settings (All Customizable)
+## Transmission Quality Indicators
 
-- **Minimum Wind Speed**: 15 mph (good for most water activities)
-- **Direction Consistency**: 70% (ensures reliable wind patterns)
-- **Required Consecutive Points**: 4 (confirms sustained conditions)
-- **Direction Variation Limit**: 45° (ensures consistent direction)
+Weather stations can experience antenna issues that cause data gaps:
 
-## Using the App
+- 🟢 **Good** — All sensors transmitting normally
+- 🟡 **Partial** — Some sensors missing data
+- 🟠 **Indoor-only** — Antenna issue (only indoor sensors reporting)
+- 🔴 **Offline** — No data being received
 
-### Main Screen
+The app distinguishes between "no wind" and "station can't transmit" so you always know what's happening.
 
-- **Current Conditions**: Real-time wind speed, direction, and quality metrics
-- **Wind Charts**: Interactive charts showing recent wind patterns
-- **Threshold Indicator**: Visual reference line based on your configured wind speed preference
-- **Manual Refresh**: Pull down to update wind data
-- **Last Updated**: Time of most recent data fetch
+## CI/CD
 
-### Settings Screen
-
-- Tap the "Settings" tab to access settings
-- **Test Different Scenarios**: Try different wind conditions to see how the alarm responds
-- **Customize Parameters**: Adjust minimum wind speed, direction consistency, and other criteria
-- **Real-time Feedback**: See immediate analysis results as you change settings
-- **Audio Testing**: Test alarm sounds with volume control
-- **Scenario Library**: Choose from pre-configured test scenarios:
-  - Good morning conditions (should trigger alarm)
-  - Weak morning winds (should not trigger alarm) 
-  - Inconsistent wind direction
-  - Wrong wind direction (opposite of preferred)
-  - Few good consecutive data points
-- Changes take effect immediately with real-time analysis update
-- Reset to defaults with a single tap
-
-### Wind Guru Tab
-
-The Wind Guru tab is an experimental feature for advanced katabatic wind predictions (disabled by default). Enable it in Settings → App Features. See the [Wind Guru Tab](#wind-guru-tab) section above for details on current functionality.
-
-## Customizing Your Experience
-
-Tailor the app to your specific needs through the Settings screen:
-
-| Setting | Purpose | When to Adjust |
-|---------|---------|----------------|
-| Minimum Wind Speed | Sets threshold for "Wake Up" decision | Increase for activities requiring stronger winds |
-| Direction Consistency | Ensures wind direction stability | Higher values for activities requiring consistent direction |
-| Consecutive Good Points | Requires sustained good conditions | Increase for more certainty, decrease for more alerts |
-| Speed Variation | Controls acceptable gustiness | Lower for activities requiring stable wind speed |
-| Direction Variation | Limits wind direction shifts | Lower for direction-sensitive activities |
-
-## Frequently Asked Questions
-
-### Why isn't my app showing current data?
-The app may be in offline mode. Check your internet connection and click the refresh button.
-
-### Can I use this for other locations?
-Currently, the app is optimized for Soda Lake (Soda Lake Dam 1) in Colorado.
-
-## Technical Features
-
-### Modern Architecture
-
-- **Service-based Audio System**: Dedicated audio service with race condition prevention
-- **Custom React Hooks**: Separation of concerns for improved code maintainability
-  - `useAlarmAudio`: Handles all audio playback and state
-  - `useWindAnalyzer`: Manages wind data analysis and scenarios
-  - `useWindAlarmReducer`: Centralizes state management for clean component logic
-- **Error Resilience**: Comprehensive error handling and recovery mechanisms
-- **Multiple Test Scenarios**: Pre-configured tests for various wind conditions
+Builds run automatically via GitHub Actions on push to `main`. See [Developer Setup](docs/developer-setup.md) for details.
 
 ## Documentation
 
-Project documentation:
-
-- 📖 **[README](README.md)** - User-facing features and usage guide (this file)
-- 👨‍💻 **[Developer Setup](docs/developer-setup.md)** - Build, deploy, and contribute
-- 🏗️ **[Architecture](docs/architecture.md)** - Technical system design
-
-## CI/CD with GitHub Actions
-
-This project uses GitHub Actions for continuous integration and delivery:
-
-- Automatic builds for Android and iOS releases
-- Environment variables securely managed through GitHub secrets
-- Complete signing and packaging for distribution
-
-For details on setting up the CI/CD environment:
-1. See [Developer Setup](docs/developer-setup.md) for CI/CD configuration details
-2. Review `.github/workflows/build-and-release.yml` for workflow configuration
+- 📖 **[README](README.md)** — User-facing features (this file)
+- 👨‍💻 **[Developer Setup](docs/developer-setup.md)** — Build, deploy, and contribute
+- 🏗️ **[Architecture](docs/architecture.md)** — Technical system design
 
 ## Coming Soon
 
-- Push notifications for ideal conditions
-- Historical accuracy tracking
+- Push notifications for ideal wind conditions
 - Server-powered Wind Guru predictions
 
 ## Contact & Support
 
-For questions, feature requests, or support open a GitHub issue in this repository
-
-## Transmission Quality Monitoring
-
-The app now includes advanced transmission quality monitoring to detect and warn users about antenna issues that can cause gaps in wind data:
-
-### Transmission Quality Features
-
-- **Antenna Issue Detection**: Automatically detects when weather stations are only transmitting indoor temperature/humidity due to antenna problems
-- **Gap Analysis**: Identifies periods where outdoor sensors (wind, temperature, humidity) are not transmitting
-- **Status Indicators**: Shows current transmission status (Good, Partial, Indoor-only, Offline)
-- **User Alerts**: Clear warnings when data gaps are caused by transmission issues, not weather conditions
-- **Chart Context**: Explains gaps in wind speed charts so users understand they're caused by antenna issues, not lack of wind
-
-### Transmission Status Types
-
-- 🟢 **Good**: All sensors transmitting normally
-- 🟡 **Partial**: Some sensors missing data
-- 🟠 **Indoor-only**: Only indoor temperature/humidity transmitting (antenna issue)
-- 🔴 **Offline**: No data being received
-
-### Why This Matters
-
-Weather stations can experience periodic antenna transmission problems that cause only indoor data to be transmitted while outdoor sensors (including wind) stop reporting. This creates gaps in wind charts that users might interpret as "no wind" when actually the station just couldn't transmit the data. The app now clearly distinguishes between these technical issues and actual weather conditions.
+For questions or feature requests, open a GitHub issue in this repository.
 

--- a/__tests__/services/sunriseService.test.ts
+++ b/__tests__/services/sunriseService.test.ts
@@ -1,0 +1,155 @@
+import axios from 'axios';
+import {
+  fetchSunriseData,
+  isBeforeSunrise,
+  getMinutesUntilSunrise,
+  SunriseData,
+} from '@/services/sunriseService';
+
+jest.mock('axios');
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('SunriseService', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('fetchSunriseData', () => {
+    const mockApiResponse = {
+      data: {
+        results: {
+          sunrise: '2026-05-20T12:00:00+00:00',
+          sunset: '2026-05-21T02:30:00+00:00',
+          solar_noon: '2026-05-20T19:15:00+00:00',
+          day_length: '14:30:00',
+          civil_twilight_begin: '2026-05-20T11:30:00+00:00',
+          civil_twilight_end: '2026-05-21T03:00:00+00:00',
+          nautical_twilight_begin: '2026-05-20T10:50:00+00:00',
+          nautical_twilight_end: '2026-05-21T03:40:00+00:00',
+          astronomical_twilight_begin: '2026-05-20T10:05:00+00:00',
+          astronomical_twilight_end: '2026-05-21T04:25:00+00:00',
+        },
+        status: 'OK',
+      },
+    };
+
+    it('should parse API response and return formatted sunrise data', async () => {
+      mockedAxios.get.mockResolvedValueOnce(mockApiResponse);
+
+      const result = await fetchSunriseData();
+
+      expect(result).not.toBeNull();
+      expect(result!.sunrise).toBe('2026-05-20T12:00:00+00:00');
+      expect(result!.sunset).toBe('2026-05-21T02:30:00+00:00');
+      expect(result!.sunriseTime).toBeInstanceOf(Date);
+      expect(result!.sunsetTime).toBeInstanceOf(Date);
+      expect(result!.formatted.sunrise).toMatch(/\d{1,2}:\d{2}\s?(AM|PM)/i);
+      expect(result!.formatted.sunset).toMatch(/\d{1,2}:\d{2}\s?(AM|PM)/i);
+    });
+
+    it('should call API with correct parameters', async () => {
+      mockedAxios.get.mockResolvedValueOnce(mockApiResponse);
+
+      await fetchSunriseData();
+
+      expect(mockedAxios.get).toHaveBeenCalledWith(
+        'https://api.sunrise-sunset.org/json',
+        expect.objectContaining({
+          params: {
+            lat: 39.6547,
+            lng: -105.1956,
+            formatted: 0,
+          },
+          timeout: 10000,
+        })
+      );
+    });
+
+    it('should return null when API returns non-OK status', async () => {
+      mockedAxios.get.mockResolvedValueOnce({
+        data: { results: {}, status: 'INVALID_REQUEST' },
+      });
+
+      const result = await fetchSunriseData();
+      expect(result).toBeNull();
+    });
+
+    it('should return null on network failure', async () => {
+      mockedAxios.get.mockRejectedValueOnce(new Error('Network Error'));
+
+      const result = await fetchSunriseData();
+      expect(result).toBeNull();
+    });
+
+    it('should return null on timeout', async () => {
+      mockedAxios.get.mockRejectedValueOnce({ code: 'ECONNABORTED' });
+
+      const result = await fetchSunriseData();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('isBeforeSunrise', () => {
+    it('should return false when sunriseData is null', () => {
+      expect(isBeforeSunrise(null)).toBe(false);
+    });
+
+    it('should return true when current time is before sunrise', () => {
+      const futureDate = new Date(Date.now() + 3600000); // 1 hour from now
+      const data: SunriseData = {
+        sunrise: futureDate.toISOString(),
+        sunset: futureDate.toISOString(),
+        sunriseTime: futureDate,
+        sunsetTime: futureDate,
+        formatted: { sunrise: '6:00 AM', sunset: '8:00 PM' },
+      };
+      expect(isBeforeSunrise(data)).toBe(true);
+    });
+
+    it('should return false when current time is after sunrise', () => {
+      const pastDate = new Date(Date.now() - 3600000); // 1 hour ago
+      const data: SunriseData = {
+        sunrise: pastDate.toISOString(),
+        sunset: pastDate.toISOString(),
+        sunriseTime: pastDate,
+        sunsetTime: pastDate,
+        formatted: { sunrise: '6:00 AM', sunset: '8:00 PM' },
+      };
+      expect(isBeforeSunrise(data)).toBe(false);
+    });
+  });
+
+  describe('getMinutesUntilSunrise', () => {
+    it('should return null when sunriseData is null', () => {
+      expect(getMinutesUntilSunrise(null)).toBeNull();
+    });
+
+    it('should return positive minutes when before sunrise', () => {
+      const futureDate = new Date(Date.now() + 30 * 60000); // 30 min from now
+      const data: SunriseData = {
+        sunrise: futureDate.toISOString(),
+        sunset: futureDate.toISOString(),
+        sunriseTime: futureDate,
+        sunsetTime: futureDate,
+        formatted: { sunrise: '6:00 AM', sunset: '8:00 PM' },
+      };
+      const minutes = getMinutesUntilSunrise(data);
+      expect(minutes).toBeGreaterThanOrEqual(29);
+      expect(minutes).toBeLessThanOrEqual(30);
+    });
+
+    it('should return negative minutes when after sunrise', () => {
+      const pastDate = new Date(Date.now() - 15 * 60000); // 15 min ago
+      const data: SunriseData = {
+        sunrise: pastDate.toISOString(),
+        sunset: pastDate.toISOString(),
+        sunriseTime: pastDate,
+        sunsetTime: pastDate,
+        formatted: { sunrise: '6:00 AM', sunset: '8:00 PM' },
+      };
+      const minutes = getMinutesUntilSunrise(data);
+      expect(minutes).toBeLessThanOrEqual(-14);
+      expect(minutes).toBeGreaterThanOrEqual(-16);
+    });
+  });
+});

--- a/components/WindStationTab.tsx
+++ b/components/WindStationTab.tsx
@@ -41,6 +41,7 @@ export default function WindStationTab({ data, config }: WindStationTabProps) {
     currentConditions,
     analysis,
     transmissionQuality,
+    sunriseData,
     isLoading,
     isLoadingCurrent,
     error,
@@ -265,6 +266,14 @@ export default function WindStationTab({ data, config }: WindStationTabProps) {
                 {formatLastUpdated(currentConditions, currentConditionsUpdated, windData)}
               </ThemedText>
             </View>
+            {sunriseData && (
+              <View style={styles.conditionItem}>
+                <ThemedText style={styles.conditionLabel}>Sunrise Today</ThemedText>
+                <ThemedText style={styles.conditionValue}>
+                  {sunriseData.formatted.sunrise}
+                </ThemedText>
+              </View>
+            )}
           </View>
           {/* Data freshness message */}
           <ThemedText style={styles.freshnessMessage}>

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture Guide
 
-Complete technical architecture overview of the Dawn Patrol Alarm application.
+Technical architecture overview of the Dawn Patrol Alarm application.
 
 ## Table of Contents
 
@@ -10,176 +10,111 @@ Complete technical architecture overview of the Dawn Patrol Alarm application.
 4. [Component Architecture](#component-architecture)
 5. [State Management](#state-management)
 6. [API Integration](#api-integration)
-7. [Android Optimizations](#android-optimizations)
+7. [Transmission Quality Monitoring](#transmission-quality-monitoring)
 8. [Performance Considerations](#performance-considerations)
-9. [Transmission Quality Monitoring](#transmission-quality-monitoring)
 
 ## System Architecture
 
 ### High-Level Overview
 
-Dawn Patrol Alarm follows a **service-oriented architecture** with clear separation of concerns:
+Dawn Patrol follows a **service-oriented architecture** with clear separation of concerns:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
 │                         UI Layer                            │
 │  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐     │
-│  │    Screens  │    │  Components │    │   Layouts   │     │
+│  │   Screens   │    │  Components │    │   Layouts   │     │
+│  │  (app/tabs) │    │ (components)│    │ (app/_layout│     │
 │  └─────────────┘    └─────────────┘    └─────────────┘     │
 ├─────────────────────────────────────────────────────────────┤
 │                    Business Logic Layer                     │
 │  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐     │
-│  │    Hooks    │    │   Analyzers │    │   Reducers  │     │
+│  │    Hooks    │    │  Contexts   │    │   Config    │     │
+│  │  (hooks/)   │    │ (contexts/) │    │  (config/)  │     │
 │  └─────────────┘    └─────────────┘    └─────────────┘     │
 ├─────────────────────────────────────────────────────────────┤
 │                      Service Layer                          │
 │  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐     │
-│  │ Weather API │    │   Storage   │    │ Audio/Alarm │     │
+│  │  Ecowitt    │    │   Storage   │    │    Wind     │     │
+│  │  Service    │    │   Service   │    │   Service   │     │
 │  └─────────────┘    └─────────────┘    └─────────────┘     │
 ├─────────────────────────────────────────────────────────────┤
 │                      Platform Layer                         │
 │  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐     │
-│  │    Expo     │    │React Native │    │   Native    │     │
+│  │  Expo SDK   │    │React Native │    │  Native iOS │     │
+│  │     55      │    │    0.83     │    │  / Android  │     │
 │  └─────────────┘    └─────────────┘    └─────────────┘     │
 └─────────────────────────────────────────────────────────────┘
 ```
 
 ### Design Principles
 
-1. **Self-Contained**: No backend server dependency
-2. **Mobile-First**: Optimized for mobile interfaces and interactions
-3. **Offline-Capable**: Cached data for reliability
-4. **Predictable**: Clear data flow and state management
-5. **Maintainable**: Modular architecture with clear boundaries
+1. **Service-based**: All API calls and data processing happen in service modules
+2. **Hook-driven UI**: Custom hooks bridge services to components
+3. **No mock data**: Errors are displayed to users, never hidden behind fake data
+4. **Offline-capable**: Cached data provides continuity during network issues
+5. **Multi-station**: Same architecture pattern replicated per weather station
 
 ## Core Services
 
-### Weather Service (`services/weatherService.ts`)
+### Ecowitt Service (`services/ecowittService.ts`)
 
-**Purpose**: Centralized weather data management with multiple data sources
-
-**Key Features**:
-- OpenWeatherMap API integration
-- Intelligent fallback system (API → Cache → Mock)
-- 30-minute caching to minimize API calls
-- Data source tracking and error handling
-
-```typescript
-// Service interface
-interface WeatherService {
-  getCurrentWeather(): Promise<WeatherData>;
-  getForecast(): Promise<ForecastData>;
-  getDataSource(): 'api' | 'cache' | 'mock';
-}
-```
-
-**Data Flow**:
-1. Request weather data
-2. Check cache validity (30 minutes)
-3. If expired, fetch from OpenWeatherMap API
-4. Fall back to cached data if API fails
-5. Fall back to mock data if all else fails
-
-### Weather Data Functionality (Removed)
-
-**Note**: The `useWeatherData.ts` hook has been **removed** as weather prediction functionality has been migrated to server-side processing.
-
-**Previous Features (Removed in Server Migration)**:
-- ~~Advanced wind prediction using 6-factor MKI meteorological analysis~~
-- ~~Local katabatic analysis factors (precipitation, sky conditions, pressure, temperature, wave patterns, atmospheric stability)~~
-- ~~MKI enhancement features and prediction tracking~~
-
-**Current Features**:
-- Basic weather data fetching from Open-Meteo API
-- Simple temperature differential calculations
-- Pressure trend analysis
-- Cache management and error handling
-
-**Server Migration**: Complex wind prediction logic moved to server infrastructure for enhanced performance and accuracy.
-
-**Calculation Process**:
-```typescript
-// Enhanced MKI calculation flow
-const calculatePrediction = (weatherData: WeatherData, waveAnalysis: MountainWaveAnalysis) => {
-  const rainScore = calculateRainFactor(weatherData);
-  const skyScore = calculateSkyFactor(weatherData);
-  const pressureScore = calculatePressureFactor(weatherData);
-  const tempScore = calculateTemperatureFactor(weatherData);
-  const waveScore = calculateWavePatternFactor(waveAnalysis);
-  const stabilityScore = calculateStabilityFactor(weatherData);
-  
-  const weightedProbability = calculateWeightedMKIScore(factors);
-  const confidence = calculateMKIConfidence(weatherData, waveAnalysis);
-  
-  return { prediction: weightedProbability, confidence, mkiFactors };
-};
-```
-
-### Mountain Wave Analyzer (`services/mountainWaveAnalyzer.ts`)
-
-**Purpose**: Analyzes mountain wave conditions for MKI integration
+**Purpose**: Primary data source — fetches wind data from Ecowitt weather stations
 
 **Key Functions**:
-- **Froude Number Calculation**: Fr = U/(N*H) for mountain wave assessment
-- **Wave Pattern Analysis**: Amplitude, organization, and surface coupling evaluation
-- **Atmospheric Stability Profiling**: Multi-layer stability assessment
-- **Enhancement Potential**: Determines positive/neutral/negative wave impact on katabatic flow
+- `fetchEcowittCombinedWindDataForDevice()` — combines historical + real-time APIs to eliminate data gaps
+- Real-time data fetching for current conditions
+- Historical data fetching for chart display
 
-**Analysis Output**:
-```typescript
-interface MountainWaveAnalysis {
-  froudeNumber: number;
-  waveAmplitude: 'low' | 'moderate' | 'high';
-  waveOrganization: 'organized' | 'mixed' | 'chaotic';
-  surfaceCoupling: 'strong' | 'moderate' | 'weak';
-  enhancement: 'positive' | 'neutral' | 'negative';
-  confidence: number;
-}
-```
+**Data Strategy**:
+- Historical API provides data from start of day
+- Real-time API provides current conditions
+- Combined approach eliminates the common 7am–1pm data gap issue
 
-### Audio Service (`services/alarmAudioService.ts`)
+### Wind Service (`services/windService.ts`)
 
-**Purpose**: Audio playback and alarm management
+**Purpose**: Wind data processing and analysis
 
-**Features**:
-- Alarm sound playback
-- Volume control
-- Background audio capabilities
-- Platform-specific optimizations
+### Wind Threshold Service (`services/windThresholdService.ts`)
+
+**Purpose**: Manages user-configured wind speed thresholds with persistence via AsyncStorage
+
+### Storage Service (`services/storageService.ts`)
+
+**Purpose**: AsyncStorage wrapper for local data persistence
+
+### Sunrise Service (`services/sunriseService.ts`)
+
+**Purpose**: Calculates sunrise/sunset times for dawn patrol timing
+
+### App Logger (`services/appLogger.ts`)
+
+**Purpose**: Centralized logging utility
+
+### Fallback Data (`services/fallbackData.ts`)
+
+**Purpose**: Provides fallback data structure when API calls fail (not mock data — used for error state display)
 
 ## Data Flow
 
-### Primary Data Flow (Simplified for Server-Based Predictions)
+### Primary Data Flow
 
 ```
-User Interface
-      ↓
-Custom Hooks (useWindData)
-      ↓
-Weather Service
-      ↓
-API/Cache/Mock Data
-      ↓
-Basic Data Processing
-      ↓
-State Updates
-      ↓
-UI Re-render
-```
-
-### State Flow Example
-
-1. **User opens app** → `useWindData` hook activates
-2. **Hook requests data** → `weatherService.getCurrentWeather()`
-3. **Service checks cache** → Valid? Return cached : Fetch new
-4. **Data processed** → Basic weather data formatting
-5. **State updated** → Simple state management
-6. **UI updates** → Components re-render with new data
-
-### Wind Guru Server Integration (Coming Soon)
-
-```
-Client Request → Server API → AI Analysis → Prediction Response → UI Update
+User opens tab (e.g., Standley Lake)
+       ↓
+useStandleyLakeWind hook activates
+       ↓
+Calls ecowittService.fetchEcowittCombinedWindDataForDevice()
+       ↓
+Ecowitt API (historical + real-time)
+       ↓
+Data processed (timestamps, units, gap detection)
+       ↓
+Transmission quality analyzed
+       ↓
+Hook state updated
+       ↓
+WindStationTab + CustomWindChart re-render
 ```
 
 ### Error Handling Flow
@@ -191,461 +126,163 @@ API Request
     ↓
 [Failure] → Check Cache
     ↓
-[Cache Valid] → Use Cached Data → Update UI
+[Cache Valid] → Use Cached Data → Update UI (with stale indicator)
     ↓
-[Cache Invalid] → Use Mock Data → Show Warning → Update UI
+[Cache Invalid] → Show Error Message → Update UI
 ```
 
 ## Component Architecture
 
 ### Screen Components (`/app`)
 
-**Structure**: File-based routing with Expo Router
 ```
 app/
-├── _layout.tsx           # Root layout with navigation
-├── (tabs)/              # Tab-based navigation
-│   ├── _layout.tsx      # Tab layout configuration
-│   ├── index.tsx        # Home/Wind data screen
-│   ├── wind-guru.tsx    # Katabatic predictions  
-│   └── ...              # Additional tab screens
-└── +not-found.tsx       # 404 error screen
+├── _layout.tsx              # Root layout, SettingsContext provider
+├── +not-found.tsx           # 404 screen
+└── (tabs)/
+    ├── _layout.tsx          # Tab bar config (5 tabs)
+    ├── index.tsx            # Soda Lake (home)
+    ├── standley-lake.tsx    # Standley Lake
+    ├── boulder-res.tsx      # Boulder Reservoir
+    ├── wind-guru.tsx        # Predictions (experimental, gated)
+    └── settings.tsx         # App settings
 ```
-
-**Key Patterns**:
-- Each screen is a functional component
-- Uses custom hooks for data and state
-- Implements error boundaries for crash recovery
-- Supports both light and dark themes
 
 ### Reusable Components (`/components`)
 
-**Organization**:
-```
-components/
-├── ui/                  # Generic UI components
-├── WindChart.tsx        # Wind data visualization
-├── WindDataDisplay.tsx  # Wind data presentation
-├── AndroidSafeWrapper.tsx # Android crash protection
-├── ErrorBoundary.tsx    # Error recovery
-└── ...                  # Feature-specific components
-```
+| Component | Purpose |
+|-----------|---------|
+| `WindStationTab.tsx` | Shared layout for wind station screens |
+| `CustomWindChart.tsx` | SVG chart with scrolling, gap handling, time labels |
+| `DayPredictionCard.tsx` | Wind prediction display card |
+| `WeeklyForecast.tsx` | 7-day forecast component |
+| `ThresholdSlider.tsx` | Wind threshold configuration slider |
+| `ErrorBoundary.tsx` | Crash recovery wrapper |
+| `HeaderImage.tsx` | Tab header image display |
+| `LoadingScreen.tsx` | Loading state display |
+| `SafeImage.tsx` | Protected image loading |
 
-**Design Patterns**:
-- **Composition over inheritance**
-- **Props-based configuration**
-- **Consistent theming support**
-- **Android-specific safety wrappers**
+### UI Primitives (`/components/ui`)
 
-### Android-Specific Components
-
-Due to Android platform challenges, several components provide crash protection:
-
-- `AndroidSafeWrapper`: Generic crash protection wrapper
-- `SafeImage`: Protected image loading
-- `WhiteScreenDetective`: White screen detection and recovery
-- `GlobalCrashRecovery`: App-wide crash recovery system
+- `IconSymbol.tsx` / `IconSymbol.ios.tsx` — Platform-specific icon rendering
+- `TabBarBackground.tsx` / `TabBarBackground.ios.tsx` — Tab bar styling
 
 ## State Management
 
-### Hook-Based State Management
+### Pattern: Custom Hooks + Context
 
-**Primary Pattern**: Custom hooks with `useReducer` for complex state
+**SettingsContext** (`contexts/SettingsContext.tsx`):
+- Wind Guru enabled/disabled toggle
+- Wind threshold preferences
+- Persisted via AsyncStorage
 
+**Station Wind Hooks**:
+- `useStationWind.ts` — Base hook for wind data fetching
+- `useStandleyLakeWind.ts` — Standley Lake specific config
+- `useSodaLakeWind.ts` — Soda Lake specific config
+- `useBoulderResWind.ts` — Boulder Reservoir specific config
+- `useWindThreshold.ts` — Threshold value management
+
+Each station hook follows the same pattern:
 ```typescript
-// Example: Wind alarm state management
-const useWindAlarmReducer = () => {
-  const [state, dispatch] = useReducer(windAlarmReducer, initialState);
-  
-  const actions = {
-    setWeatherData: (data: WeatherData) => 
-      dispatch({ type: 'SET_WEATHER_DATA', payload: data }),
-    setPrediction: (prediction: KatabaticPrediction) =>
-      dispatch({ type: 'SET_PREDICTION', payload: prediction }),
-    // ... other actions
-  };
-  
-  return { state, actions };
-};
+const { windData, loading, error, refresh, transmissionQuality } = useStandleyLakeWind();
 ```
 
-### State Structure
+### Theme
 
-```typescript
-interface AppState {
-  // Weather data
-  currentWeather: WeatherData | null;
-  forecast: ForecastData | null;
-  
-  // Predictions
-  todayPrediction: KatabaticPrediction | null;
-  tomorrowPrediction: KatabaticPrediction | null;
-  
-  // UI state
-  loading: boolean;
-  error: string | null;
-  dataSource: 'api' | 'cache' | 'mock';
-  
-  // Settings
-  userPreferences: UserPreferences;
-}
-```
-
-### Context Usage
-
-Context is used sparingly, primarily for:
-- Theme management (light/dark mode)
-- Global error handling
-- User preferences
-- Debug settings (development only)
+- `useColorScheme.ts` / `useColorScheme.web.ts` — System theme detection
+- `useThemeColor.ts` — Color values for current theme
 
 ## API Integration
 
-### OpenWeatherMap Integration
+### Ecowitt API (Primary)
 
-**Configuration**:
-```typescript
-const weatherConfig = {
-  baseUrl: 'https://api.openweathermap.org/data/2.5',
-  apiKey: process.env.OPENWEATHER_API_KEY,
-  locations: {
-    morrison: { lat: 39.6525, lon: -105.1178 },
-    nederland: { lat: 39.9617, lon: -105.5067 }
-  }
-};
-```
+**Authentication**: Application key + API key + device MAC address
 
-**Data Processing**:
-1. Fetch current weather for both elevation points
-2. Fetch 5-day forecast for trend analysis
-3. Convert units (Kelvin → Fahrenheit, m/s → mph)
-4. Extract relevant time windows (2-5 AM, 6-8 AM)
-5. Calculate gradients and changes
+**Endpoints**:
 
-### Ecowitt Integration (Optional)
+| Endpoint | Purpose |
+|----------|---------|
+| `/api/v3/device/real_time` | Current conditions (last 2 hours) |
+| `/api/v3/device/history` | Historical data (5-min resolution for past 90 days) |
 
-**Purpose**: Standley Lake real-time monitoring
-**Configuration**: Requires separate API credentials
-**Usage**: Supplementary data source for Front Range conditions
+**Configuration** (`config/ecowittConfig.ts`):
+- Station MAC addresses
+- Device names and locations
+- API parameter defaults
 
-### Caching Strategy
+**Unit Configuration**:
+| Measurement | Default |
+|-------------|---------|
+| Wind Speed | mph (`wind_speed_unitid: 9`) |
+| Temperature | °F (`temp_unitid: 2`) |
+| Pressure | inHg (`pressure_unitid: 4`) |
 
-**Cache Duration**: 30 minutes for weather data
-**Storage**: AsyncStorage for persistence across app sessions
-**Validation**: Timestamp-based expiration
-**Fallback**: Graceful degradation to mock data
+**History Resolution Constraints**:
+| Time Range | Resolution | Max Span |
+|---|---|---|
+| Past 90 days | 5 min | 1 day |
+| Past 365 days | 30 min | 1 week |
+| Past 730 days | 240 min | 1 month |
 
-## Android Optimizations
+### OpenWeatherMap API (Secondary)
 
-### Crash Prevention
-
-**Challenge**: Android platform instability with React Native
-**Solution**: Multi-layered protection system
-
-1. **Error Boundaries**: Catch and recover from component crashes
-2. **Safe Wrappers**: Protect crash-prone native operations
-3. **White Screen Detection**: Detect and recover from white screen crashes
-4. **Global Recovery**: App-wide crash recovery with state restoration
-
-### Memory Management
-
-- **Image Optimization**: Proper image loading and disposal
-- **Component Cleanup**: Cleanup timers and listeners
-- **Memory Monitoring**: Debug tools for memory leak detection
-
-### Performance Optimizations
-
-- **Lazy Loading**: Load components only when needed
-- **Efficient Re-renders**: useMemo and useCallback optimization
-- **Background Processing**: Minimize main thread blocking
-
-## Performance Considerations
-
-### Data Fetching Optimization
-
-1. **Intelligent Caching**: 30-minute cache prevents excessive API calls
-2. **Background Updates**: Refresh data without blocking UI
-3. **Optimistic Updates**: Show cached data immediately, update when fresh data arrives
-
-### Rendering Optimization
-
-1. **Component Memoization**: Prevent unnecessary re-renders
-2. **State Colocational**: Keep state close to where it's used
-3. **Virtualization**: Efficient list rendering for large datasets (future consideration)
-
-### Bundle Size Management
-
-1. **Tree Shaking**: Remove unused code
-2. **Dynamic Imports**: Load features on demand
-3. **Asset Optimization**: Compress images and fonts
-
-### Network Efficiency
-
-1. **Request Batching**: Combine multiple API calls when possible
-2. **Compression**: Enable gzip for API responses
-3. **Connection Pooling**: Reuse connections for better performance
-
-## MKI Integration Architecture
-
-### Mountain Wave-Katabatic Interaction Implementation
-
-The Phase 4 MKI integration represents a significant architectural enhancement that transforms the prediction system from basic meteorological analysis to sophisticated atmospheric science modeling.
-
-### Enhanced Prediction Pipeline
-
-```
-Weather Data Input
-      ↓
-Basic Meteorological Analysis (4 factors)
-      ↓
-Mountain Wave Analysis (NEW)
-      ↓
-Atmospheric Stability Profiling (NEW)
-      ↓
-MKI Integration & Enhancement Calculation
-      ↓
-6-Factor Weighted Prediction with Confidence
-```
-
-### New Service Integration
-
-**Mountain Wave Analyzer Service**:
-- Calculates Froude numbers for wave assessment
-- Analyzes wave amplitude, organization, and surface coupling
-- Determines enhancement potential (positive/neutral/negative)
-- Integrates with main prediction pipeline
-
-**Enhanced Katabatic Analyzer**:
-- Rebalanced factor weights for 6-factor system (25%, 20%, 20%, 15%, 15%, 5%)
-- Advanced bonus system with MKI-aware calculations
-- Multi-scale confidence assessment
-- Nonlinear interaction modeling
-
-### Technical Implementation Benefits
-
-1. **Accuracy Improvement**: Target 15-25% increase in prediction accuracy
-2. **Edge Case Handling**: Better handling of marginal conditions with wave enhancement
-3. **Scientific Foundation**: First practical consumer implementation of MKI research
-4. **Scalable Architecture**: Foundation for future machine learning integration
-
-### Performance Considerations for MKI
-
-- **Computation Caching**: Complex Froude number calculations cached for 30 minutes
-- **Background Processing**: Wave analysis performed asynchronously
-- **Graceful Degradation**: Falls back to 4-factor system if wave data unavailable
-- **Memory Optimization**: Efficient wave pattern data structures
-
-## Security Considerations
-
-### API Key Management
-
-- **Environment Variables**: Never commit API keys to version control
-- **Runtime Configuration**: Support for dynamic key configuration
-- **Secure Storage**: Use Expo SecureStore for sensitive data
-
-### Data Privacy
-
-- **Local Processing**: All analysis happens on-device
-- **No User Tracking**: No personal data collection
-- **Minimal Permissions**: Request only necessary device permissions
+Used for weather forecast data. Configured via `OPENWEATHER_API_KEY` environment variable.
 
 ## Transmission Quality Monitoring
 
 ### Overview
 
-The app includes comprehensive transmission quality monitoring to detect and handle antenna issues that cause incomplete data transmission from weather stations.
+Detects antenna issues that cause incomplete data transmission from weather stations, distinguishing "station can't transmit" from "no wind."
 
 ### Implementation
 
-#### Core Components
+**Analysis Functions**:
+- `analyzeDataPointTransmissionQuality()` — per-reading analysis
+- `analyzeOverallTransmissionQuality()` — temporal pattern detection
 
-1. **TransmissionQualityInfo Interface**
-   - `isFullTransmission`: Boolean indicating complete sensor data
-   - `hasOutdoorSensors`: Boolean for outdoor temperature/humidity availability
-   - `hasWindData`: Boolean for wind sensor availability
-   - `transmissionGaps`: Array of detected gaps with timing and type
-   - `currentTransmissionStatus`: Current status (good/partial/indoor-only/offline)
+**Quality States**:
+- `good` — All sensors reporting
+- `partial` — Some sensors missing
+- `indoor-only` — Antenna issue (only indoor sensors transmitting)
+- `offline` — No data received
 
-2. **Data Point Analysis**
-   - `analyzeDataPointTransmissionQuality()`: Analyzes individual readings
-   - Detects missing outdoor sensors vs. indoor-only transmissions
-   - Identifies antenna issues when only indoor data is transmitted
+**Integration**:
+- Station wind hooks include `transmissionQuality` in their return value
+- UI displays color-coded status indicators
+- Chart gaps are annotated with transmission context
 
-3. **Temporal Analysis**
-   - `analyzeOverallTransmissionQuality()`: Analyzes patterns over time
-   - Detects gaps and their duration
-   - Categorizes gap types (antenna, offline, partial)
-
-#### Integration Points
-
-1. **Data Fetching**
-   - Modified API calls to request wind + outdoor + indoor data
-   - Enhanced response parsing to detect missing fields
-   - Quality metadata attached to each data point
-
-2. **Hook Updates**
-   - `useSodaLakeWind` and `useStandleyLakeWind` now include transmission quality
-   - Automatic analysis on data refresh
-   - State management for quality information
-
-3. **UI Components**
-   - Transmission status indicators in current conditions
-   - Detailed alerts for antenna issues
-   - Chart context explanations for data gaps
-   - Color-coded status messages
-
-#### Data Flow
+### Data Flow
 
 ```
 API Response → Data Point Analysis → Quality Metadata → Hook State → UI Alerts
-     ↓                                      ↓                          ↓
-Enhanced Parsing → Individual Assessment → Overall Analysis → User Warnings
 ```
 
-### Benefits
+## Performance Considerations
 
-1. **User Understanding**: Clear distinction between technical issues and weather conditions
-2. **Data Transparency**: Users know when gaps are due to transmission problems
-3. **Reliability**: Better interpretation of incomplete data
-4. **Troubleshooting**: Helps identify station hardware issues
+### Data Fetching
+- Combined historical + real-time API calls minimize round-trips
+- Auto-refresh only on first tab navigation (not every focus)
+- Pull-to-refresh for manual updates
 
-## Wind Prediction System Architecture
+### Rendering
+- SVG-based charts (CustomWindChart) for smooth scrolling
+- Proper gap handling avoids false interpolation
+- Dynamic chart width based on data range
 
-### Hybrid 5-Factor Implementation Summary
+### Caching
+- AsyncStorage for data persistence across sessions
+- Stale data shown immediately while fresh data loads
+- Configurable cache duration per data type
 
-Successfully updated the Wind Guru prediction system from a theoretical 6-factor system to a practical 5-factor hybrid system combining NOAA and OpenWeather APIs with real meteorological data.
+## Security
 
-#### 1. Hybrid Weather Service (`hybridWeatherService.ts`)
-- **Primary NOAA Integration**: Rain probability, sky cover, temperature grids, transport winds
-- **Secondary OpenWeather Integration**: Pressure trends and backup data
-- **Smart Fallback Logic**: NOAA → OpenWeather → Cache → Mock data progression
-- **Data Source Tracking**: Real-time monitoring of which API provides each factor
+### API Key Management
+- Environment variables (`.env`) — never committed to version control
+- GitHub Actions secrets for CI/CD builds
+- No API keys bundled in app binary (injected at build time via `app.config.js`)
 
-#### 2. Updated 5-Factor Katabatic Analyzer (`katabaticAnalyzer.ts`)
-**Current Factors:**
-- **Factor #1 - Rain Probability (25% weight)**: NOAA precipitation forecasts
-- **Factor #2 - Clear Sky Conditions (25% weight)**: NOAA sky cover analysis  
-- **Factor #3 - Pressure Change (20% weight)**: OpenWeather pressure trends
-- **Factor #4 - Temperature Differential (15% weight)**: NOAA temperature grid data
-- **Factor #5 - Wave Pattern Analysis (10% weight)**: NOAA transport winds + mixing height data
-
-**Algorithm Enhancements:**
-- Rebalanced factor weights for 5-factor system (25%/25%/20%/15%/10%)
-- Enhanced bonus system for multiple favorable factors
-- Improved confidence calculation accounting for hybrid data sources
-
-#### Factor Weighting System
-```
-precipitation: 25%        (replaces atmospheric stability)
-skyConditions: 25%        (same) 
-pressureChange: 20%       (same)
-temperatureDifferential: 15%  (same)
-wavePattern: 10%          (updated: uses transportWindAnalysis)
-```
-
-#### Confidence Calculation
-- **High Confidence**: 4+ factors met with hybrid data reliability
-- **Medium Confidence**: 3-4 factors met with some data uncertainty
-- **Low Confidence**: <3 factors met or significant data gaps
-
-#### Bonus System (Updated for 5-factor)
-- **4+ factors met**: 20% bonus
-- **5 factors met**: Additional 25% bonus (45% total)
-- **Positive wave enhancement**: Additional 10% bonus when confidence >70%
-
-### Wind Guru Enhancement Plan: MKI Integration
-
-#### Current System Strengths
-- 5-factor analysis system (Precipitation, Sky Conditions, Pressure, Temperature, Wave Pattern) 
-- Confidence calculation with factor weighting
-- Real-time verification and learning
-- User-friendly presentation with probability and recommendations
-
-#### Future Enhancement Phases
-
-**Phase 1: Enhanced Data Collection**
-- Synoptic Wind Data: Upper-level wind speed and direction (2-4km altitude)
-- Atmospheric Stability: Calculate Brunt-Väisälä frequency and stability profile
-- Froude Number: Compute Fr = U/NH for mountain wave assessment
-- Multi-level Temperature: Temperature profiles for stability analysis
-- Enhanced Pressure Data: Higher temporal resolution pressure measurements
-
-**Phase 2: MKI Factor Integration**
-- Wave Pattern Factor: Calculate Froude number from synoptic conditions
-- Atmospheric Stability Factor: Multi-layer stability optimization
-- Expand factor weighting system to 6 factors
-- Update recommendation logic for MKI scenarios
-
-**Phase 3: Advanced Prediction Logic**
-- Multi-scale Variability Modeling (mesoscale/microscale)
-- Enhanced Pressure Analysis with wave-induced modifications
-- Coupling Efficiency Calculation for wave energy transmission
-
-**Phase 4: Advanced UI/UX**
-- Enhanced factor display with MKI-specific explanations
-- Advanced prediction windows based on wave evolution
-- Activity-specific MKI guidance and safety considerations
-
-## Ecowitt API Reference
-
-The app uses the [Ecowitt API v3](https://api.ecowitt.net/api/v3/) to retrieve weather station data for all monitored stations (Soda Lake, Standley Lake, and Boulder Reservoir).
-
-### Authentication
-
-All requests require:
-- `application_key` — Ecowitt developer application key
-- `api_key` — Account-level API key
-- `mac` — Device MAC address (e.g., `FF:FF:FF:FF:FF:FF`)
-
-### Endpoints
-
-#### Real-Time Data
-
-```
-GET https://api.ecowitt.net/api/v3/device/real_time
-```
-
-Returns the latest data (within past 2 hours). Key parameters:
-- `call_back` — Fields to return (e.g., `outdoor`, `indoor.humidity`, or `all`)
-- `wind_speed_unitid` — `9` for mph (default), `7` for km/h, `8` for knots
-
-#### Device History
-
-```
-GET https://api.ecowitt.net/api/v3/device/history
-```
-
-Returns historical data with resolution constraints:
-| Time Range | Resolution | Max Span per Request |
-|---|---|---|
-| Past 90 days | 5 min | 1 day |
-| Past 365 days | 30 min | 1 week |
-| Past 730 days | 240 min | 1 month |
-| Past 1460 days | 24 hours | 1 year |
-
-Key parameters:
-- `start_date` / `end_date` — ISO 8601 format (e.g., `2022-01-01 00:00:00`)
-- `cycle_type` — `auto`, `5min`, `30min`, `4hour`, or `1day`
-- `call_back` — Fields to return (supports comma-separated, e.g., `outdoor.temp,indoor.humidity`)
-
-### Unit Options
-
-| Measurement | Parameter | Values |
-|---|---|---|
-| Temperature | `temp_unitid` | `1` = °C, `2` = °F (default) |
-| Wind Speed | `wind_speed_unitid` | `6` = m/s, `7` = km/h, `8` = knots, `9` = mph (default) |
-| Pressure | `pressure_unitid` | `3` = hPa, `4` = inHg (default), `5` = mmHg |
-| Rainfall | `rainfall_unitid` | `12` = mm, `13` = in (default) |
-
-### Response Format
-
-```json
-{
-  "code": 0,
-  "msg": "success",
-  "time": "1649409577",
-  "data": { ... }
-}
-```
-
-Non-zero `code` values indicate errors. The `data` object structure varies by endpoint and `call_back` parameter.
+### Data Privacy
+- All processing happens on-device
+- No user tracking or personal data collection
+- Minimal permissions (network access only)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -588,7 +588,7 @@ wavePattern: 10%          (updated: uses transportWindAnalysis)
 
 ## Ecowitt API Reference
 
-The app uses the [Ecowitt API v3](https://api.ecowitt.net/api/v3/) to retrieve weather station data for Standley Lake monitoring.
+The app uses the [Ecowitt API v3](https://api.ecowitt.net/api/v3/) to retrieve weather station data for all monitored stations (Soda Lake, Standley Lake, and Boulder Reservoir).
 
 ### Authentication
 

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -10,15 +10,18 @@ Complete setup guide for developers working on the Dawn Patrol Alarm project.
 4. [Project Structure](#project-structure)
 5. [Key Technologies](#key-technologies)
 6. [Development Guidelines](#development-guidelines)
+7. [Build & Deployment](#build-process--deployment)
+8. [Ecowitt Sensors](#ecowitt-sensor-troubleshooting)
 
 ## Prerequisites
 
 ### Required Tools
 
-- **Node.js** (v18 or higher)
+- **Node.js** (v20 or higher)
 - **npm** (comes with Node.js)
 - **Expo CLI** (installed via npm)
 - **Git** for version control
+- **JDK 17** for Android builds (`JAVA_HOME=/opt/homebrew/opt/openjdk@17`)
 
 ### Mobile Development
 
@@ -30,99 +33,46 @@ Complete setup guide for developers working on the Dawn Patrol Alarm project.
 - Android Studio with Android SDK
 - Android Emulator or physical Android device
 - USB debugging enabled for physical devices
+- `ANDROID_HOME` and `ANDROID_SDK_ROOT` environment variables set
 
-### API Accounts (Optional but Recommended)
+### API Accounts
 
-- **OpenWeatherMap**: Free API key for real weather data
-- **Ecowitt**: API credentials for Standley Lake monitoring
+- **Ecowitt**: API credentials for Standley Lake and Soda Lake monitoring (required)
+- **OpenWeatherMap**: API key for weather forecasts (required)
 
 ## Environment Setup
 
 ### 1. Clone and Install
 
 ```bash
-# Clone the repository
-git clone [repository-url]
+git clone https://github.com/samqbush/dp-soda.git
 cd dp-react
-
-# Install dependencies
 npm install
 ```
 
 ### 2. Environment Configuration
 
 ```bash
-# Copy environment template
 cp .env.example .env
 ```
 
-Edit `.env` file with your API credentials:
+Edit `.env` with your API credentials:
 
 ```bash
-# OpenWeatherMap API (recommended for real data)
-OPENWEATHER_API_KEY=your_api_key_here
-
-# Ecowitt API (optional - for Standley Lake monitoring) 
 ECOWITT_APPLICATION_KEY=your_application_key_here
 ECOWITT_API_KEY=your_api_key_here
+OPENWEATHER_API_KEY=your_openweather_api_key_here
 ```
 
-**Note**: The app works without API keys using cached/mock data, but real API keys provide better accuracy.
+**Note**: The app requires valid API keys. Without them, data will not load and errors will be displayed.
 
 ### 3. Verify Setup
 
 ```bash
-# Start development server
 npm start
-
-# Alternative: start with tunnel for external device testing
-npx expo start --tunnel
 ```
 
 ## Development Workflow
-
-### Android Development Setup
-
-**⚠️ Important: Always ensure Android emulator is running before starting development**
-
-#### Quick Android Setup Check
-```bash
-# Check your Android development environment
-npm run android-setup
-```
-
-#### Safe Android Development (Recommended)
-```bash
-# Automatically starts emulator if needed, then runs the app
-npm run android-safe
-```
-
-**⚠️ VS Code Task Environment Issue:**  
-If you encounter Java Runtime errors when running the VS Code task, use the terminal directly:
-```bash
-# Run directly in terminal (bypasses VS Code environment issues)
-npx expo run:android
-```
-This works because your shell environment (with Java from sdkman) is properly loaded in the terminal but may not be inherited by VS Code tasks.
-
-#### Manual Android Development
-```bash
-# 1. Start emulator manually (if not already running)
-emulator -avd YourEmulatorName
-
-# 2. Verify device is connected
-adb devices
-
-# 3. Run the app
-npm run android
-```
-
-**Common Android Issues & Solutions:**
-- **"Unable to locate a Java Runtime"** → Run `npx expo run:android` directly in terminal instead of using VS Code tasks
-- **"No Android connected device found"** → Use `npm run android-safe` instead
-- **Emulator not detected** → Ensure `ANDROID_HOME` and `ANDROID_SDK_ROOT` are set
-- **ADB not found** → Add `$ANDROID_HOME/platform-tools` to PATH
-- **Emulator command not found** → Add `$ANDROID_HOME/emulator` to PATH
 
 ### Daily Development
 
@@ -133,219 +83,142 @@ npm run android
 
 2. **Choose your development platform**
    - Press `i` for iOS Simulator
-   - Press `a` for Android Emulator (ensure emulator is running first!)
-   - Scan QR code with Expo Go app on physical device
+   - Press `a` for Android Emulator
+   - Press `w` for web browser
+   - Scan QR code with Expo Go on a physical device
 
-3. **Live reload** - Changes automatically refresh the app
+3. **Live reload** — changes automatically refresh the app
+
+### Running on Android
+
+```bash
+# Run on connected emulator/device
+npm run android
+
+# If you get Java Runtime errors in VS Code tasks, run directly in terminal:
+npx expo run:android
+```
+
+**Common Android Issues:**
+- **"Unable to locate a Java Runtime"** → Ensure `JAVA_HOME` points to JDK 17
+- **Emulator not detected** → Verify `ANDROID_HOME` is set and emulator is running
+- **ADB not found** → Add `$ANDROID_HOME/platform-tools` to PATH
+
+### Running on iOS
+
+```bash
+npm run ios
+```
 
 ### Code Quality
 
 ```bash
-# Check for linting issues and compilation errors
+# Lint (ESLint + TypeScript + YAML workflow validation)
 npm run lint
 
-# Fix auto-fixable linting issues
-npm run lint:fix
-
-# Type checking (TypeScript)
+# Type checking only
 npx tsc --noEmit
 ```
 
 ### Testing
 
 ```bash
-# Run unit tests  
+# Run unit tests
 npm test
 
 # Run tests with coverage
 npm run test:coverage
 
-# Run tests in watch mode during development
+# Run tests in watch mode
 npm run test:watch
+
+# Run specific test suites
+npm run test:wind
+npm run test:data
+npm run test:utils
+
+# End-to-end tests (Playwright)
+npm run test:e2e
+npm run test:e2e:web
+npm run test:e2e:headed
 ```
 
 ## Project Structure
 
 ```
 dp-react/
-├── app/                    # Main application screens (Expo Router)
-│   ├── _layout.tsx         # Root layout and navigation
-│   ├── (tabs)/            # Tab-based navigation screens
-│   └── +not-found.tsx     # 404 error screen
-├── components/             # Reusable UI components
-│   ├── ui/                # Generic UI components  
-│   ├── WindChart.tsx      # Wind data visualization
-│   ├── WindDataDisplay.tsx # Wind data presentation
-│   └── ...                # Component files
-├── hooks/                  # Custom React hooks
-│   ├── useWindData.ts     # Wind data fetching
-│   └── ...                # Hook files (useWeatherData.ts removed)
-├── services/               # Business logic and API services
-│   ├── weatherService.ts  # Weather API integration
-│   ├── alarmAudioService.ts # Audio/notification handling
-│   └── ...                # Service files
-├── utils/                  # Helper functions and utilities
-├── config/                 # Configuration files
-├── assets/                 # Static assets (images, fonts, sounds)
-├── docs/                   # Documentation (you are here!)
-└── ...                    # Root configuration files
+├── app/                       # Screens (Expo Router file-based routing)
+│   ├── _layout.tsx            # Root layout and navigation
+│   ├── +not-found.tsx         # 404 screen
+│   └── (tabs)/                # Tab navigation
+│       ├── _layout.tsx        # Tab bar configuration
+│       ├── index.tsx          # Home/Soda Lake tab
+│       ├── standley-lake.tsx  # Standley Lake wind tab
+│       ├── boulder-res.tsx    # Boulder Reservoir wind tab
+│       ├── wind-guru.tsx      # Wind Guru predictions tab
+│       └── settings.tsx       # Settings tab
+├── components/                # Reusable UI components
+│   ├── ui/                    # Generic UI primitives
+│   ├── CustomWindChart.tsx    # SVG wind chart with scrolling
+│   ├── WindStationTab.tsx     # Shared wind station display
+│   ├── DayPredictionCard.tsx  # Wind prediction card
+│   ├── WeeklyForecast.tsx     # 7-day forecast display
+│   ├── ThresholdSlider.tsx    # Wind threshold config
+│   ├── ErrorBoundary.tsx      # Crash recovery wrapper
+│   └── ...                    # Other shared components
+├── hooks/                     # Custom React hooks
+│   ├── useStationWind.ts      # Base wind data hook
+│   ├── useStandleyLakeWind.ts # Standley Lake data
+│   ├── useSodaLakeWind.ts     # Soda Lake data
+│   ├── useBoulderResWind.ts   # Boulder Reservoir data
+│   ├── useWindThreshold.ts    # Threshold settings
+│   └── useColorScheme.ts      # Theme detection
+├── services/                  # Business logic and APIs
+│   ├── ecowittService.ts      # Ecowitt API integration
+│   ├── windService.ts         # Wind data processing
+│   ├── windThresholdService.ts # Threshold persistence
+│   ├── sunriseService.ts      # Sunrise/sunset times
+│   ├── storageService.ts      # AsyncStorage wrapper
+│   ├── appLogger.ts           # Logging utility
+│   └── fallbackData.ts        # Fallback data for errors
+├── config/                    # Configuration
+│   └── ecowittConfig.ts       # Station device configs
+├── scripts/                   # Dev/debug scripts
+│   ├── debug-dp-stations.mjs  # Station data debugging
+│   ├── debug-ecowitt-devices.mjs # Device connectivity
+│   ├── verify-noaa-data.mjs   # NOAA data quality check
+│   └── increment-version.mjs  # Version bump utility
+├── __tests__/                 # Test files (mirrors src structure)
+├── assets/                    # Static assets (images, fonts, sounds)
+├── docs/                      # Documentation
+└── .github/workflows/         # CI/CD pipeline
 ```
-
-### Key Directories Explained
-
-**`/app`** - Screen components using Expo Router
-- File-based routing system
-- Each file represents a screen or layout
-- Supports nested routes and tabs
-
-**`/components`** - Reusable UI components
-- Organized by functionality
-- Includes both generic and app-specific components
-- Android-specific fixes and wrappers
-
-**`/hooks`** - Custom React hooks
-- Data fetching and state management
-- Business logic abstraction
-- Reusable stateful logic
-
-**`/services`** - Core business logic
-- API integrations (OpenWeatherMap, Ecowitt)
-- Data processing and analysis
-- Audio and notification services
-- **Note**: Wind prediction services moved to server-based architecture
-
-## Recent Major Updates
-
-### Wind Guru Server Migration (June 30, 2025)
-The Wind Guru prediction system has been converted from a complex local prediction system to a server-based solution:
-
-**Migration Overview:**
-- **Removed Local Prediction Logic**: Eliminated 3000+ lines of complex katabatic analysis code
-- **Simplified Client**: Wind Guru tab now shows server migration status and coming features
-- **Enhanced Performance**: Server-based predictions will provide faster and more accurate results
-- **Code Reduction**: 87% reduction in Wind Guru related code (from ~3000+ lines to ~400 lines)
-
-**Removed Services:**
-- `services/katabaticAnalyzer.ts` (1165 lines) - Main prediction algorithm
-- `services/predictionStateManager.ts` (~400 lines) - Locked prediction state management
-- `services/predictionTrackingService.ts` (~500 lines) - Accuracy tracking and outcomes
-- `services/eveningWeatherRefreshService.ts` (~300 lines) - Auto 6PM data refresh
-- `services/freeHistoricalWeatherService.ts` (~275 lines) - Historical weather enhancement
-- `hooks/useKatabaticAnalyzer.ts` (~200 lines) - React hook for prediction analysis
-
-**Simplified Files:**
-- `app/(tabs)/wind-guru.tsx` - From 2057 lines to ~400 lines (80% reduction)
-- `hooks/useWeatherData.ts` - **REMOVED** (was simplified from 977 to 152 lines, then removed entirely)
-- `app/_layout.tsx` - Removed wind prediction service initialization
-
-**Previous System (Removed):**
-- ~~Local 5-factor hybrid MKI analysis~~
-- ~~Real-time prediction state management~~
-- ~~Historical verification tracking~~
-- ~~Evening weather refresh automation~~
-- ~~Complex atmospheric stability calculations~~
-- ~~Thermal cycle temperature analysis~~
-- ~~Wave pattern enhancement detection~~
-
-**New System (In Development):**
-- Server-based katabatic wind analysis
-- Enhanced machine learning models
-- Improved atmospheric pattern recognition
-- Multi-location comparative analysis
-- Centralized prediction logic for better maintainability
-
-**Benefits of Server Migration:**
-1. **Reduced Client Complexity**: Massive code reduction and simplified architecture
-2. **Better Performance**: No local processing overhead, instant server results
-3. **Enhanced Accuracy**: Access to more comprehensive weather datasets and ML models
-4. **Improved Maintainability**: Centralized logic, easier updates and debugging
-5. **Scalability**: Server can handle complex calculations and real-time data processing
-
-## Recent Improvements
-
-### Wind Data Chart Enhancements (Latest)
-
-**Key Improvements Made:**
-- ✅ **Eliminated data gaps** by implementing combined historical + real-time API approach
-- ✅ **Improved chart UX** with CustomWindChart component featuring:
-  - Professional time-based x-axis labeling (hourly with AM/PM, quarter-hour marks)
-  - Horizontal scrolling with sticky Y-axis labels
-  - Proper gap handling (line breaks for missing data)
-  - Dynamic width based on data range
-- ✅ **Streamlined refresh UX** - removed refresh button, now pull-to-refresh only
-- ✅ **Optimized performance** - auto-refresh only on first navigation to tabs
-- ✅ **Better data freshness** - shows current time coverage and last updated timestamp
-
-**Technical Changes:**
-- **ecowittService.ts**: Added `fetchEcowittCombinedWindDataForDevice()` combining historical and real-time APIs
-- **CustomWindChart.tsx**: SVG-based chart replacing legacy React Native Chart Kit implementation  
-- **Removed unused components**: VictoryWindChart, legacy WindChart
-- **Cleaned debug scripts**: Removed 20+ temporary investigation scripts
-
-**Data Coverage Solution:**
-- Historical API provides data from start of day up to ~10:20am
-- Real-time API provides current conditions and recent data
-- Combined approach eliminates the 7am-1pm data gap issue
-
-## Wind Data Gap Investigation (Resolved)
-
-### Issue
-Large gaps appeared in wind data charts between 7AM-1PM, despite Ecowitt web UI showing data for those periods.
-
-### Investigation Results
-Comprehensive API testing with multiple parameters, timezones, and cycle types revealed:
-
-**✅ Root Cause Confirmed**: Gaps exist in the raw Ecowitt API data itself, not in app processing.
-
-**Key Findings**:
-- API returns 130 total data points but with consistent gaps:
-  - GAP 1: 07:00 AM → 08:25 AM (85 minutes)
-  - GAP 2: 08:35 AM → 11:40 AM (185 minutes) ← Main visible gap
-  - GAP 3: 04:20 PM → 05:00 PM (40 minutes)
-- Same gaps appear across all test scenarios (different timezones, cycle types, parameters)
-- Even when requesting ONLY 7AM-1PM data, API returns the same internal gaps
-- Real-time API works but only provides current moment, not historical gap-filling
-
-**Conclusion**: The weather station itself had data collection/transmission issues during these periods. The Ecowitt web UI may show interpolated or cached data that the API doesn't provide.
-
-### Solution
-**Accepted as normal behavior** for historical weather APIs. The app correctly processes all available data.
-
-**Current Implementation**:
-- Uses `fetchEcowittCombinedWindDataForDevice()` for historical + real-time data
-- CustomWindChart properly displays gaps with line breaks (no false interpolation)
-- Professional chart with proper time labeling and horizontal scrolling
 
 ## Key Technologies
 
 ### Core Framework
-- **Expo** - React Native framework with managed workflow
-- **React Native** - Cross-platform mobile development
-- **TypeScript** - Type-safe JavaScript development
-- **Expo Router** - File-based navigation system
-
-### State Management  
-- **React Hooks** - Built-in state management
-- **Custom Reducers** - Complex state logic
-- **Context API** - Global state sharing
+- **Expo SDK 55** — React Native framework (managed workflow)
+- **React Native 0.83** — Cross-platform mobile
+- **React 19** — UI library
+- **TypeScript 5.9** — Type safety
+- **Expo Router** — File-based navigation
 
 ### UI/UX
-- **React Navigation v7** - Navigation library
-- **Expo Vector Icons** - Icon library
-- **Custom Themes** - Light/dark mode support
-- **Responsive Design** - Mobile-first approach
+- **React Navigation v7** — Navigation library
+- **React Native SVG** — Chart rendering
+- **Expo Vector Icons** — Icon library
+- **Light/Dark mode** — System theme support
 
 ### APIs & Data
-- **OpenWeatherMap API** - Real weather data
-- **Ecowitt API** - Standley Lake monitoring
-- **AsyncStorage** - Local data persistence
-- **Expo SecureStore** - Secure credential storage
+- **Ecowitt API** — Wind station data (Standley Lake, Soda Lake)
+- **OpenWeatherMap API** — Weather forecasts
+- **AsyncStorage** — Local data persistence
 
-### Development Tools
-- **ESLint** - Code linting and style enforcement
-- **Prettier** - Code formatting
-- **TypeScript** - Static type checking
-- **Jest** - Unit testing framework
+### Development & Testing
+- **ESLint** — Linting (with expo config)
+- **Jest 29** — Unit testing
+- **Playwright** — End-to-end testing
+- **Husky** — Git hooks (pre-commit)
 
 ## Development Guidelines
 
@@ -358,7 +231,6 @@ Comprehensive API testing with multiple parameters, timezones, and cycle types r
 
 2. **Component Structure**
    ```typescript
-   // Good component structure
    interface ComponentProps {
      // Define props with types
    }
@@ -368,9 +240,7 @@ Comprehensive API testing with multiple parameters, timezones, and cycle types r
      const [state, setState] = useState();
      
      // Event handlers
-     const handleAction = () => {
-       // Handler logic
-     };
+     const handleAction = () => {};
      
      // Render
      return (
@@ -386,23 +256,12 @@ Comprehensive API testing with multiple parameters, timezones, and cycle types r
 
 ### API Integration
 
-1. **Use the weatherService abstraction**
+1. **Use service abstractions** — never make API calls directly in components
    ```typescript
-   // Good - use the service
-   import { weatherService } from '@/services/weatherService';
-   
-   // Bad - direct API calls in components
+   import { ecowittService } from '@/services/ecowittService';
    ```
 
-2. **Handle errors gracefully**
-   ```typescript
-   try {
-     const data = await weatherService.getCurrentWeather();
-     // Handle success
-   } catch (error) {
-     // Handle error with user-friendly message
-   }
-   ```
+2. **Handle errors gracefully** — display user-friendly error messages, never mock data
 
 3. **Implement proper loading states**
    ```typescript
@@ -410,45 +269,39 @@ Comprehensive API testing with multiple parameters, timezones, and cycle types r
    const [error, setError] = useState<string | null>(null);
    ```
 
-### Android-Specific Considerations
+### Git Workflow
 
-1. **Use Android-safe wrappers** for crash-prone components
-2. **Test on physical devices** - emulators may not catch all issues
-3. **Implement proper error boundaries** for crash recovery
-4. **Use debugging components** when troubleshooting Android issues
+1. **Create feature branches** from `main`
+2. **Make small, focused commits** with clear messages
+3. **Run linting** before committing: `npm run lint` (enforced by Husky pre-commit hook)
+4. **Create pull requests** for code review
+5. **Merge after review** and CI checks pass
+6. **Production build** triggers automatically on merge to main
 
-### Build Process & Deployment
+---
 
-**Dawn Patrol Alarm uses GitHub Actions for all production builds**:
-- ✅ **No local build setup required**
-- ✅ **Consistent build environment**
-- ✅ **Automated Android optimizations**
-- ✅ **Integrated testing and validation**
-- ✅ **Automatic version management**
+## Build Process & Deployment
 
-#### Local Development
-Use `npm start` for testing and development
+**All production builds run via GitHub Actions** (`.github/workflows/build-and-release.yml`):
+- ✅ No local build setup required for releases
+- ✅ Consistent build environment (macOS for iOS, Ubuntu for Android)
+- ✅ Integrated linting, testing, and code signing
+- ✅ Automatic version increment
+- ✅ Artifacts published to GitHub Releases
 
-#### Production Builds
-All production builds are handled automatically via GitHub Actions workflow (`.github/workflows/build.yml`):
+### Build Triggers
 
-**Supported Platforms**:
-- **Android**: APK and AAB (Android App Bundle) builds
-- **iOS**: IPA builds for TestFlight distribution
-
-**Build Triggers**:
 - Push to `main` branch (automatic)
 - Manual trigger via GitHub Actions "Run workflow" button
 
-**Build Process**:
-1. Environment setup (Node.js, Expo CLI, Android SDK)
-2. Dependency installation with caching
-3. Code quality checks (ESLint, TypeScript, tests)
-4. Version increment (patch level)
-5. Platform-specific optimizations
-6. Artifact generation and distribution
+### Build Pipeline
 
-#### GitHub Repository Secrets
+1. **Lint & Test** (Ubuntu) — ESLint, TypeScript, Jest with coverage
+2. **iOS Build** (macOS) — Expo prebuild → Xcode archive → signed IPA
+3. **Android Build** (Ubuntu) — Expo prebuild → Gradle → signed AAB + APK
+4. **Release** — Creates GitHub Release with all artifacts
+
+### GitHub Repository Secrets
 
 Required secrets for the build process:
 
@@ -460,310 +313,151 @@ ANDROID_KEY_PASSWORD       # Key password
 ANDROID_KEYSTORE_PASSWORD  # Keystore password
 ```
 
+**Expo**:
+```
+EXPO_TOKEN                 # Expo authentication token for CI builds
+```
+
+**iOS Signing** (Team ID: FAF3YHR4P4):
+```
+IOS_DIST_CERTIFICATE_P12_BASE64       # Base64 encoded .p12 distribution certificate
+IOS_DIST_CERTIFICATE_PASSWORD         # Password for the .p12 file
+IOS_DIST_PROVISIONING_PROFILE_BASE64  # Base64 encoded .mobileprovision file
+IOS_DIST_CODE_SIGN_IDENTITY           # e.g. "Apple Distribution: Samuel James (FAF3YHR4P4)"
+```
+
 **API Keys**:
 ```
 OPENWEATHER_API_KEY        # OpenWeatherMap API key
-ECOWITT_APPLICATION_KEY    # Ecowitt app key (optional)
-ECOWITT_API_KEY           # Ecowitt API key (optional)
+ECOWITT_APPLICATION_KEY    # Ecowitt app key
+ECOWITT_API_KEY           # Ecowitt API key
 ```
 
-**Setting Up Secrets**:
-1. Go to GitHub repository → Settings → Secrets and variables → Actions
-2. Click "New repository secret"
-3. Add each required secret with the exact name and value
-
-#### Release Process
-
-1. **Prepare Release**: Ensure features are complete and tested
-2. **Trigger Build**: Push to main branch or manually trigger workflow
-3. **Monitor Build**: Watch GitHub Actions progress
-4. **Distribute**: Download artifacts and distribute via chosen channels
-
-#### Distribution
-
-**Android APK**:
-- Primary distribution via GitHub Releases
-- Direct APK download links
-- Manual installation requires "Unknown Sources" permission
-
-**iOS TestFlight** (if configured):
-- Automatic upload to TestFlight
-- Beta tester notifications
-- Internal testing (up to 100 testers, no review)
-- External testing (up to 10,000 testers, requires Beta App Review)
-
-#### Build Troubleshooting
-
-**Common Issues**:
-- "Invalid keystore" Error: Verify keystore base64 encoding and secrets
-- "API key missing" Warning: Non-critical, app uses fallback data
-- "Version conflict" Error: Manual version bump may be needed
-
-**Debug Commands**:
+**Setting Up Secrets via `gh` CLI**:
 ```bash
-# Test locally before pushing
-npm run lint
-npm run test
-
-# Environment debugging
-npm run debug-env          # Check environment variables
-npm run validate-keys      # Validate API keys  
-npm run test-apis          # Test API connectivity
+gh secret set SECRET_NAME --repo samqbush/dp-soda < secret_file.txt
+# or inline:
+gh secret set SECRET_NAME --repo samqbush/dp-soda --body "value"
 ```
 
-### Git Workflow
+### iOS Distribution Certificate Renewal
 
-1. **Create feature branches** from `main`
-2. **Make small, focused commits** with clear messages
-3. **Run linting** before committing: `npm run lint`
-4. **Create pull requests** for code review
-5. **Merge after review** and CI checks pass
-6. **Production build** triggers automatically on merge to main
+The iOS Distribution Certificate expires annually. Apple sends an email 30 days before expiry. Follow these steps to renew.
 
-### Debugging
+**Prerequisites**:
+- Apple Developer account access (Team ID: FAF3YHR4P4)
+- Keychain Access app (macOS)
+- `gh` CLI authenticated (`gh auth status`)
 
-1. **Use React Developer Tools** for component inspection
-2. **Enable remote debugging** in Expo DevTools
-3. **Use console.log** strategically (remove before production)
-4. **Utilize Android debugging components** for Android-specific issues
-5. **Check network requests** in browser dev tools
+**Step 1: Generate a new certificate in Apple Developer Portal**
 
-### Performance
+1. Sign in at https://developer.apple.com/account/resources/certificates/list
+2. Click the **+** button to create a new certificate
+3. Select **Apple Distribution** and click Continue
+4. Upload a Certificate Signing Request (CSR):
+   - Open **Keychain Access** → Certificate Assistant → Request a Certificate From a Certificate Authority
+   - Enter your email, select "Saved to disk", click Continue
+   - Upload the generated `.certSigningRequest` file
+5. Download the generated `.cer` file
 
-1. **Minimize API calls** - use caching where appropriate
-2. **Optimize images** - use appropriate formats and sizes
-3. **Lazy load components** when possible
-4. **Profile performance** using React DevTools Profiler
-5. **Test on lower-end devices** to ensure smooth experience
+**Step 2: Export as .p12 from Keychain Access**
 
-## Evening Weather Refresh Service
+1. Double-click the downloaded `.cer` file to install it in Keychain Access
+2. In Keychain Access, find the certificate under "My Certificates"
+3. Right-click → Export → choose `.p12` format
+4. Set a strong password (you'll need this for the secret)
+5. Save as `distribution.p12`
 
-The app includes an automatic evening weather refresh system that ensures accurate overnight wind predictions.
+**Step 3: Regenerate the Provisioning Profile**
 
-### Purpose
-The evening refresh service solves the issue where pressure change and temperature differential would show 0.0 values when the app transitions from afternoon to evening analysis mode at 6 PM.
+1. Go to https://developer.apple.com/account/resources/profiles/list
+2. Find your App Store distribution profile (or create a new one)
+3. Edit it and select the **new** distribution certificate
+4. Download the `.mobileprovision` file
 
-### How It Works
-1. **Automatic Scheduling**: Service schedules a background notification for 6 PM daily
-2. **Silent Refresh**: At 6 PM, weather data is automatically refreshed in the background
-3. **Fresh Data**: Ensures pressure trends and temperature differentials are calculated with current data
-4. **User Transparency**: Status is visible in the Wind Guru screen header
-
-### Key Files
-- `services/generalNotificationService.ts` - General purpose notification system
-- `services/eveningWeatherRefreshService.ts` - Main service implementation
-- `services/alarmNotificationService.ts` - Alarm-specific notifications (separate from general)
-- `app/(tabs)/wind-guru.tsx` - UI status display
-
-### Debug Commands
-```bash
-# Test the evening refresh service
-npm run debug-evening-refresh
-
-# Check current status and trigger manual refresh
-node scripts/debug-evening-refresh.mjs
-```
-
-### Configuration
-The service automatically initializes when the app starts and requires notification permissions to function properly. No additional configuration is needed.
-
-## Prediction Lifecycle Management
-
-The app implements a robust prediction lifecycle management system to ensure wind predictions are locked at appropriate times and maintain consistency throughout the prediction window.
-
-> **📋 For complete workflow details, see [Wind Guru Prediction Workflow](./wind-guru-prediction-workflow.md)**
-
-### Purpose
-The prediction lifecycle management solves timing issues where predictions would dramatically change after midnight due to forecast data transitions. It implements a structured approach to prediction reliability:
-
-### Lifecycle Stages
-1. **Preview (Morning-Evening)**: Predictions calculated normally, updated with fresh data
-2. **Evening Lock (6 PM)**: First lock point - prediction locked for evening review
-3. **Final Lock (11 PM)**: Second lock point - prediction locked for dawn execution
-4. **Active (Midnight-8 AM)**: Locked prediction used, no recalculation
-5. **Verification (8 AM)**: Compare predicted vs actual conditions
-
-### Key Features
-- **Automatic Locking**: Predictions automatically lock at 6 PM and 11 PM
-- **State Persistence**: Locked predictions saved and restored between app sessions
-- **Consistent Results**: Same prediction shown from evening through dawn
-- **Verification**: Post-event analysis to improve prediction accuracy
-
-### Key Files
-- `services/predictionStateManager.ts` - Core prediction lifecycle management
-- `services/katabaticAnalyzer.ts` - Integrated prediction analysis with state management
-
-### Testing
-```bash
-# Debug current prediction state and real wind data
-npm run debug-stations  # Shows real wind data for verification
-```
-
-### Configuration
-The prediction lifecycle system automatically initializes when first accessed and requires no manual configuration. It uses AsyncStorage for persistence and includes automatic cleanup of old predictions.
-
-## Getting Help
-
-- **Issues**: Create GitHub issues for bugs or feature requests  
-- **Architecture**: See [Architecture Guide](architecture.md) for system design
-- **Wind Prediction**: See [Wind Prediction Guide](wind-prediction-guide.md) for technical details
-
-## Next Steps
-
-Once you have the development environment set up:
-
-1. **Explore the codebase** - Start with `/app` directory for main screens
-2. **Review architecture** - Read [Architecture Guide](architecture.md)
-3. **Understand wind prediction** - See [Wind Prediction Guide](wind-prediction-guide.md)
-4. **Make your first change** - Try updating a component or adding a feature
-5. **Test thoroughly** - Ensure changes work on both iOS and Android
-6. **Deploy** - Push to main branch to trigger automated build and release
-
-## Ecowitt Sensor Investigation & Troubleshooting
-
-The app uses real weather data from Ecowitt weather stations at Standley Lake and Soda Lake. This section documents investigation findings and troubleshooting procedures.
-
-### Current Status (Last Updated: June 2025)
-
-**Standley Lake Station (GW2000B_V3.2.5)**:
-- ✅ **Excellent reliability**: 100% data coverage with no gaps
-- ✅ **All sensors operational**: Wind, temperature, humidity, pressure, rain, solar
-- ✅ **Consistent wind data**: Reliable source for wind predictions
-- 📍 **Location**: 39.870467, -105.151622
-
-**Soda Lake Station (GW3000B_V1.0.6)**:  
-- ⚠️ **Intermittent wind data**: ~52% coverage (151/288 daily readings have wind data)
-- ✅ **Sensors functional**: When connected, all sensors work properly
-- ✅ **Temperature/humidity reliable**: Consistent outdoor readings
-- 🔧 **Issue**: Periodic RF connectivity problems with wind sensor array
-- 📍 **Location**: 39.646115, -105.174958
-
-### Device Comparison
-
-| Feature | Standley (GW2000B) | Soda (GW3000B) |
-|---------|-------------------|----------------|
-| **Gateway Type** | Basic outdoor gateway | Advanced console with display |
-| **Indoor Sensors** | Via external sensors only | Built-in to console unit |
-| **Reliability** | Excellent (100%) | Good but intermittent wind |
-| **Sensor Array** | Haptic array, 2.6V battery | Haptic array, 3.18V battery |
-| **Connectivity** | Stable RF connection | Intermittent RF issues |
-
-### Common Issues & Solutions
-
-**Missing Wind Data**:
-- **Symptom**: Historical data shows gaps in wind readings
-- **Cause**: RF interference or signal strength issues 
-- **Solution**: Improve Soda Lake RF connectivity (antenna placement, signal strength)
-
-**Indoor Temperature Readings**:
-- **Normal Behavior**: GW3000B consoles measure indoor conditions where installed
-- **Explanation**: Gateway unit placed indoors provides indoor temp/humidity
-- **Not a Bug**: This is expected behavior for console-type devices
-
-**Battery Status**:
-- **Healthy Range**: 2.4V - 3.2V for sensor arrays
-- **Warning**: <2.4V may cause connectivity issues
-- **Critical**: <2.2V requires immediate battery replacement
-
-### Investigation Tools
-
-Use these debugging scripts to investigate sensor issues:
+**Step 4: Get the Code Sign Identity name**
 
 ```bash
-# Check individual station data and connectivity
-npm run debug-stations
-
-# Verify device connectivity and sensor status
-npm run debug-devices
-
-# Verify NOAA weather data quality  
-npm run verify-noaa
+security find-identity -v -p codesigning | grep "Apple Distribution"
 ```
 
-### Key Findings from Investigation
-
-1. **API Data Accuracy**: Ecowitt API returns correct data counts (288 5-minute intervals = 24 hours)
-2. **Sensor Connectivity**: Both stations show all sensors connected in real-time checks
-3. **Intermittent Issues**: Soda Lake wind sensor has periodic RF connectivity problems
-4. **Hardware Status**: All sensor batteries healthy, no hardware failures detected
-5. **Indoor Sensors**: Normal operation for GW3000B console units
-
-### Recommendations for App Development
-
-1. **Data Quality Focus**: Improve Soda Lake sensor connectivity for more reliable wind data
-2. **Data Validation**: Add checks for missing wind periods and implement graceful fallbacks
-3. **User Feedback**: Display data quality indicators and gaps clearly in UI
-4. **Monitoring**: Set up alerts for extended sensor outages at the primary location
-5. **RF Optimization**: Consider antenna placement and signal strength improvements
-
-### Technical Details
-
-**Compatible Sensor Arrays**:
-- WS85, WS90, WS80, WS68, WS69 (wind/weather arrays)
-- WH40 (rain gauge), WH57 (lightning detector)
-- WH45/WH46 (air quality), WN34L/S/D (temperature sensors)
-
-**RF Specifications**:
-- Frequency: 915MHz (US), 868MHz (EU), 433MHz (Asia)
-- Range: 100+ meters in open areas
-- Protocol: Proprietary Ecowitt wireless
-
-## API Migration History
-
-### Phase 1: Open-Meteo Migration (Completed June 21, 2025)
-
-Successfully migrated from OpenWeatherMap to Open-Meteo API to eliminate API blocking issues and costs.
-
-#### Objectives Achieved
-1. **Primary Weather API Switch**
-   - **From**: OpenWeatherMap (rate-limited, paid, blocked)
-   - **To**: Open-Meteo (unlimited, free, high-quality)
-   - **Result**: ✅ Eliminated API blocking issues
-
-2. **Aggressive Caching Implementation**
-   - **From**: 30-minute cache duration
-   - **To**: 6-hour cache duration (12x improvement)
-   - **Benefits**: 
-     - 🚀 Reduced API dependency
-     - ⚡ Faster app performance  
-     - 📶 Better offline capability
-     - 💰 Zero API costs
-
-#### Technical Implementation
-- **New Files Created**:
-  - `services/openMeteoWeatherService.ts` - Complete Open-Meteo integration
-  - `scripts/test-open-meteo-integration.mjs` - API validation script
-
-- **Files Modified**:
-  - `hooks/useWeatherData.ts` - Switched to Open-Meteo service
-  - `app/(tabs)/wind-guru.tsx` - Updated UI to show new data source
-  - `package.json` - Added test script
-
-#### Key Features
-- **No API Keys Required** - Open-Meteo is completely free
-- **Comprehensive Data** - Current weather + 7-day hourly forecasts
-- **High Quality Sources** - European reanalysis data (ERA5, ECMWF IFS)
-- **Smart Caching** - 6-hour cache with stale data fallback
-- **Error Recovery** - Graceful degradation with mock data
-
-#### Performance Results
+Output will look like:
 ```
-✅ Morrison API Response: 200
-   Current Temp: 33.2°C
-   Pressure: 985.4 hPa
-   Wind: 2.51 m/s
-   Forecast Hours: 168
-
-✅ Evergreen API Response: 200
-   Current Temp: 30.5°C
-   Pressure: 985.8 hPa
-
-🌡️ Temperature Differential: 2.7°C
-⚡ API Performance: ~159ms average
+1) ABC123... "Apple Distribution: Samuel James (FAF3YHR4P4)"
 ```
 
-#### Benefits Achieved
-- **Cost Elimination**: $0 API costs with Open-Meteo
-- **Reliability Improvement**: No limits, no blocks, unlimited requests
-- **Performance Enhancement**: 6-hour cache, 12x fewer API calls
-- **Development Velocity**: Zero configuration, works immediately
+**Step 5: Update GitHub secrets with `gh` CLI**
+
+```bash
+# Base64 encode the certificate and provisioning profile
+base64 -i distribution.p12 > cert_b64.txt
+base64 -i profile.mobileprovision > profile_b64.txt
+
+# Update all iOS signing secrets
+gh secret set IOS_DIST_CERTIFICATE_P12_BASE64 --repo samqbush/dp-soda < cert_b64.txt
+gh secret set IOS_DIST_CERTIFICATE_PASSWORD --repo samqbush/dp-soda --body "your-p12-password"
+gh secret set IOS_DIST_PROVISIONING_PROFILE_BASE64 --repo samqbush/dp-soda < profile_b64.txt
+gh secret set IOS_DIST_CODE_SIGN_IDENTITY --repo samqbush/dp-soda --body "Apple Distribution: Samuel James (FAF3YHR4P4)"
+
+# Clean up sensitive files
+rm -f distribution.p12 cert_b64.txt profile_b64.txt profile.mobileprovision
+```
+
+**Step 6: Verify the new certificate works**
+
+```bash
+gh workflow run "Build Dawn Patrol Alarm - Combined Release" --repo samqbush/dp-soda
+gh run watch --repo samqbush/dp-soda
+```
+
+**Notes**:
+- The old certificate can be revoked after confirming the new build succeeds
+- Provisioning profiles are tied to a specific certificate — always regenerate after cert renewal
+- The code sign identity string rarely changes unless you change your developer account name
+
+### Release & Distribution
+
+1. Push to `main` or manually trigger the workflow
+2. Monitor at: `https://github.com/samqbush/dp-soda/actions`
+3. On success, artifacts are attached to a GitHub Release
+
+**Android**: APK + AAB available as GitHub Release assets
+**iOS**: IPA available for manual upload to App Store Connect / TestFlight
+
+### Build Troubleshooting
+
+| Error | Solution |
+|-------|----------|
+| Invalid keystore | Verify `ANDROID_KEYSTORE_BASE64` encoding |
+| iOS signing failure | Check cert expiry, regenerate per steps above |
+| Version conflict | Run `npm run increment-version` locally and push |
+
+---
+
+## Ecowitt Sensor Troubleshooting
+
+The app uses real weather data from Ecowitt weather stations at Standley Lake and Soda Lake.
+
+### Station Status
+
+**Standley Lake (GW2000B_V3.2.5)**:
+- ✅ Excellent reliability: ~100% data coverage
+- 📍 Location: 39.870467, -105.151622
+
+**Soda Lake (GW3000B_V1.0.6)**:
+- ⚠️ Intermittent wind data (~52% coverage due to RF issues)
+- 📍 Location: 39.646115, -105.174958
+
+### Debug Scripts
+
+```bash
+npm run debug-stations       # Station data and wind readings
+npm run debug-devices        # Device connectivity and sensor status
+npm run verify-noaa          # NOAA data quality check
+```
+
+### Common Issues
+
+- **Missing wind data gaps** → Normal for Ecowitt API; the app handles gaps gracefully with line breaks in charts
+- **Indoor temperature on Soda Lake** → Expected behavior for GW3000B console units (measures where installed)
+- **Battery warning** → Sensor arrays need replacement below 2.4V

--- a/docs/developer-setup.md
+++ b/docs/developer-setup.md
@@ -46,7 +46,7 @@ Complete setup guide for developers working on the Dawn Patrol Alarm project.
 
 ```bash
 git clone https://github.com/samqbush/dp-soda.git
-cd dp-react
+cd dp-soda
 npm install
 ```
 
@@ -146,7 +146,7 @@ npm run test:e2e:headed
 ## Project Structure
 
 ```
-dp-react/
+dp-soda/
 ├── app/                       # Screens (Expo Router file-based routing)
 │   ├── _layout.tsx            # Root layout and navigation
 │   ├── +not-found.tsx         # 404 screen

--- a/hooks/useSodaLakeWind.ts
+++ b/hooks/useSodaLakeWind.ts
@@ -1,6 +1,9 @@
 import { useStationWind, type UseStationWindReturn } from './useStationWind';
+import { fetchSunriseData, type SunriseData } from '@/services/sunriseService';
+import { useCallback, useEffect, useState } from 'react';
 
 export interface UseSodaLakeWindReturn extends UseStationWindReturn {
+  sunriseData: SunriseData | null;
   loadCachedData: () => Promise<boolean>;
 }
 
@@ -11,8 +14,34 @@ export const useSodaLakeWind = (): UseSodaLakeWindReturn => {
     defaultAlarmTime: '05:00'
   });
 
+  const [sunriseData, setSunriseData] = useState<SunriseData | null>(null);
+
+  const refreshSunrise = useCallback(async () => {
+    try {
+      const data = await fetchSunriseData();
+      setSunriseData(data);
+    } catch (error) {
+      console.error('Error fetching sunrise data:', error);
+    }
+  }, []);
+
+  // Fetch sunrise data on mount
+  useEffect(() => {
+    refreshSunrise();
+  }, [refreshSunrise]);
+
+  // Wrap refreshData to also refresh sunrise
+  const refreshData = useCallback(async () => {
+    await Promise.all([
+      stationWind.refreshData(),
+      refreshSunrise()
+    ]);
+  }, [stationWind.refreshData, refreshSunrise]);
+
   return {
     ...stationWind,
+    refreshData,
+    sunriseData,
     loadCachedData: async () => false
   };
 };

--- a/services/sunriseService.ts
+++ b/services/sunriseService.ts
@@ -1,0 +1,114 @@
+/**
+ * Sunrise/Sunset Service
+ * Fetches sunrise and sunset times for Morrison, Colorado using the sunrise-sunset.org API
+ */
+
+import axios from 'axios';
+
+// Morrison, Colorado coordinates (same as NOAA scripts)
+const MORRISON_COORDS = {
+  lat: 39.6547,
+  lng: -105.1956
+};
+
+export interface SunriseData {
+  sunrise: string; // ISO string from API
+  sunset: string;
+  sunriseTime: Date;
+  sunsetTime: Date;
+  formatted: {
+    sunrise: string; // e.g., "6:45 AM"
+    sunset: string;  // e.g., "7:30 PM"
+  };
+}
+
+interface SunriseApiResponse {
+  results: {
+    sunrise: string;
+    sunset: string;
+    solar_noon: string;
+    day_length: string;
+    civil_twilight_begin: string;
+    civil_twilight_end: string;
+    nautical_twilight_begin: string;
+    nautical_twilight_end: string;
+    astronomical_twilight_begin: string;
+    astronomical_twilight_end: string;
+  };
+  status: string;
+}
+
+/**
+ * Format a Date to a user-friendly time string in Mountain Time
+ */
+const formatMountainTime = (date: Date): string => {
+  return date.toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: 'America/Denver'
+  });
+};
+
+/**
+ * Fetch sunrise and sunset times for Morrison, Colorado
+ * Returns null on failure (graceful degradation)
+ */
+export async function fetchSunriseData(): Promise<SunriseData | null> {
+  try {
+    const response = await axios.get<SunriseApiResponse>(
+      'https://api.sunrise-sunset.org/json',
+      {
+        params: {
+          lat: MORRISON_COORDS.lat,
+          lng: MORRISON_COORDS.lng,
+          formatted: 0 // Request ISO 8601 UTC times
+        },
+        timeout: 10000,
+        headers: {
+          'User-Agent': 'DawnPatrol/1.0'
+        }
+      }
+    );
+
+    if (response.data.status !== 'OK') {
+      console.error('Sunrise API returned error status:', response.data.status);
+      return null;
+    }
+
+    const { sunrise, sunset } = response.data.results;
+    const sunriseTime = new Date(sunrise);
+    const sunsetTime = new Date(sunset);
+
+    return {
+      sunrise,
+      sunset,
+      sunriseTime,
+      sunsetTime,
+      formatted: {
+        sunrise: formatMountainTime(sunriseTime),
+        sunset: formatMountainTime(sunsetTime)
+      }
+    };
+  } catch (error) {
+    console.error('Failed to fetch sunrise data:', error);
+    return null;
+  }
+}
+
+/**
+ * Check if the current time is before sunrise
+ */
+export function isBeforeSunrise(sunriseData: SunriseData | null): boolean {
+  if (!sunriseData) return false;
+  return new Date() < sunriseData.sunriseTime;
+}
+
+/**
+ * Get minutes until sunrise (negative if past sunrise)
+ */
+export function getMinutesUntilSunrise(sunriseData: SunriseData | null): number | null {
+  if (!sunriseData) return null;
+  const diff = sunriseData.sunriseTime.getTime() - Date.now();
+  return Math.floor(diff / 60000);
+}

--- a/services/sunriseService.ts
+++ b/services/sunriseService.ts
@@ -64,10 +64,7 @@ export async function fetchSunriseData(): Promise<SunriseData | null> {
           lng: MORRISON_COORDS.lng,
           formatted: 0 // Request ISO 8601 UTC times
         },
-        timeout: 10000,
-        headers: {
-          'User-Agent': 'DawnPatrol/1.0'
-        }
+        timeout: 10000
       }
     );
 

--- a/services/windService.ts
+++ b/services/windService.ts
@@ -76,7 +76,7 @@ export const analyzeWindData = (
   let alarmWindowData: WindDataPoint[];
 
   if (skipTimeFilter) {
-    // Data is already filtered by the caller (e.g., verifyWindConditions)
+    // Data is already filtered by the caller
     alarmWindowData = data;
   } else {
     // Filter data for the alarm window (3am-5am)

--- a/types/windStation.ts
+++ b/types/windStation.ts
@@ -5,7 +5,7 @@ import {
   TransmissionQualityInfo 
 } from '@/services/ecowittService';
 import { WindDataPoint, WindAnalysis } from '@/services/windService';
-import { SunriseData } from '@/services/sunriseService';
+import type { SunriseData } from '@/services/sunriseService';
 
 export interface WindStationData {
   // Data state

--- a/types/windStation.ts
+++ b/types/windStation.ts
@@ -5,6 +5,7 @@ import {
   TransmissionQualityInfo 
 } from '@/services/ecowittService';
 import { WindDataPoint, WindAnalysis } from '@/services/windService';
+import { SunriseData } from '@/services/sunriseService';
 
 export interface WindStationData {
   // Data state
@@ -13,6 +14,7 @@ export interface WindStationData {
   currentConditions: EcowittCurrentWindConditions | null;
   analysis: WindAnalysis | null;
   transmissionQuality?: TransmissionQualityInfo | null;
+  sunriseData?: SunriseData | null;
   
   // Loading and error states
   isLoading: boolean;


### PR DESCRIPTION
## Summary

Adds a new **Boulder Reservoir** tab for wind monitoring, following the same pattern as the existing Soda Lake and Standley Lake tabs. Also adds **sunrise/sunset time display** to the Soda Lake tab using the sunrise-sunset.org API.

## Changes

### Boulder Reservoir Tab
- **`hooks/useBoulderResWind.ts`** — New hook wrapping `useStationWind` with Ecowitt device "DP Boulder Res", 270° West preferred direction, 06:00 default alarm time
- **`app/(tabs)/boulder-res.tsx`** — New tab screen using the shared `WindStationTab` component
- **`app/(tabs)/_layout.tsx`** — Registers the Boulder Res tab between Standley Lake and Wind Guru
- **`components/ui/IconSymbol.tsx`** — Adds `drop.fill` → `water-drop` icon mapping for the tab bar icon

### Sunrise Feature (Soda Lake)
- **`services/sunriseService.ts`** — New service fetching sunrise/sunset from sunrise-sunset.org API (no key required)
- **`hooks/useSodaLakeWind.ts`** — Extended to fetch and expose sunrise data
- **`types/windStation.ts`** — Added optional `sunriseData` field to `WindStationData`
- **`components/WindStationTab.tsx`** — Conditionally renders sunrise time in conditions grid
- **`__tests__/services/sunriseService.test.ts`** — Unit tests for the sunrise service

## Device Info

- **Ecowitt device name:** DP Boulder Res
- **MAC address:** 5C:01:3B:44:CB:D3
- **Preferred wind direction:** 270° (West)

## External Dependencies

- **sunrise-sunset.org API** — Free, no API key needed, 1 req/sec rate limit. Returns UTC times; we convert to Mountain Time for display. Graceful degradation (returns null on failure, UI simply hides the sunrise item).

## Testing

- ✅ `npm run lint` passes (ESLint + TypeScript + YAML)
- ✅ All Jest tests pass (including new sunrise service tests)
- ✅ Verified tab renders correctly via Playwright browser test at `/boulder-res`